### PR TITLE
Fix circular model dependencies and improve schema organization

### DIFF
--- a/src/app/create_database.py
+++ b/src/app/create_database.py
@@ -9,9 +9,9 @@ from src.app.models.dqm1.item import Item
 from src.app.models.dqm1.monster import (
     MonsterBreedingLink,
     MonsterDetail,
-    MonsterFamily,
     MonsterSkillLink,
 )
+from src.app.models.dqm1.monster_family import MonsterFamily
 from src.app.models.dqm1.skill import Skill, SkillCombine
 
 

--- a/src/app/create_database.py
+++ b/src/app/create_database.py
@@ -1,19 +1,15 @@
 import csv
 from pathlib import Path
 
-from sqlmodel import Session, select
 from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session, select
 
 from src.app.database import create_db_and_tables, engine
+from src.app.models.dqm1.associations import MonsterSkillLink
 from src.app.models.dqm1.item import Item
-from src.app.models.dqm1.monster import (
-    MonsterBreedingLink,
-    MonsterDetail,
-    MonsterSkillLink,
-)
+from src.app.models.dqm1.monster import MonsterBreedingLink, MonsterDetail
 from src.app.models.dqm1.monster_family import MonsterFamily
 from src.app.models.dqm1.skill import Skill, SkillCombine
-
 
 current_dir = Path(__file__).resolve().parent
 csv_dir = current_dir.parent / "csv_files"

--- a/src/app/models/dqm1/associations.py
+++ b/src/app/models/dqm1/associations.py
@@ -1,0 +1,19 @@
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+
+class MonsterSkillLink(SQLModel, table=True):
+    """
+    many-to-many association table linking a monster to three different skills.
+    """
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    monster_id: Optional[int] = Field(
+        default=None,
+        foreign_key="monsterdetail.id",
+    )
+    skill_id: Optional[int] = Field(
+        default=None,
+        foreign_key="skill.id",
+    )

--- a/src/app/models/dqm1/monster.py
+++ b/src/app/models/dqm1/monster.py
@@ -4,6 +4,7 @@ from sqlmodel import Field, Relationship, SQLModel
 
 if TYPE_CHECKING:
     from .skill import Skill
+    from .monster_family import MonsterFamily, MonsterFamilyRead
 
 
 class MonsterSkillLink(SQLModel, table=True):
@@ -48,33 +49,8 @@ class MonsterDetailRead(MonsterDetailBase):
     id: int
 
 
-class MonsterFamilyBase(SQLModel):
-    """
-    There are 10 monster families in the game.
-    """
-
-    family_eng: str
-
-
-class MonsterFamily(MonsterFamilyBase, table=True):
-    """
-    one-to-many relation between family and monsters.
-    """
-
-    id: Optional[int] = Field(default=None, primary_key=True)
-    monsters: List[MonsterDetail] = Relationship(back_populates="family")
-
-
-class MonsterFamilyRead(MonsterFamilyBase):
-    id: int
-
-
 class MonsterDetailWithFamily(MonsterDetailRead):
     family: Optional[MonsterFamilyRead]
-
-
-class MonsterFamilyReadWithMonsterDetail(MonsterFamilyRead):
-    monsters: List[MonsterDetailRead] = []
 
 
 class MonsterBreedingLinkBase(SQLModel):

--- a/src/app/models/dqm1/monster.py
+++ b/src/app/models/dqm1/monster.py
@@ -2,25 +2,11 @@ from typing import List, Optional, TYPE_CHECKING
 
 from sqlmodel import Field, Relationship, SQLModel
 
+from .associations import MonsterSkillLink
+
 if TYPE_CHECKING:
     from .skill import Skill
-    from .monster_family import MonsterFamily, MonsterFamilyRead
-
-
-class MonsterSkillLink(SQLModel, table=True):
-    """
-    many-to-many association table linking a monster to three different skills.
-    """
-
-    id: Optional[int] = Field(default=None, primary_key=True)
-    monster_id: Optional[int] = Field(
-        default=None,
-        foreign_key="monsterdetail.id",
-    )
-    skill_id: Optional[int] = Field(
-        default=None,
-        foreign_key="skill.id",
-    )
+    from .monster_family import MonsterFamily
 
 
 class MonsterDetailBase(SQLModel):
@@ -39,18 +25,10 @@ class MonsterDetailBase(SQLModel):
 class MonsterDetail(MonsterDetailBase, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
 
-    family: List["MonsterFamily"] = Relationship(back_populates="monsters")
+    family: Optional["MonsterFamily"] = Relationship(back_populates="monsters")
     skills: List["Skill"] = Relationship(
         back_populates="monsters", link_model=MonsterSkillLink
     )
-
-
-class MonsterDetailRead(MonsterDetailBase):
-    id: int
-
-
-class MonsterDetailWithFamily(MonsterDetailRead):
-    family: Optional[MonsterFamilyRead]
 
 
 class MonsterBreedingLinkBase(SQLModel):
@@ -112,15 +90,3 @@ class MonsterBreedingLink(MonsterBreedingLinkBase, table=True):
             "lazy": "joined",
         }
     )
-
-
-class MonsterBreedingLinkRead(MonsterBreedingLinkBase):
-    id: int
-
-
-class MonsterBreedingLinkReadWithInfo(MonsterBreedingLinkRead):
-    child: Optional[MonsterDetailRead]
-    pedigree: Optional[MonsterDetailRead]
-    parent2: Optional[MonsterDetailRead]
-    pedigree_family: Optional[MonsterFamilyRead]
-    family2: Optional[MonsterFamilyRead]

--- a/src/app/models/dqm1/monster_family.py
+++ b/src/app/models/dqm1/monster_family.py
@@ -3,7 +3,7 @@ from typing import List, Optional, TYPE_CHECKING
 from sqlmodel import Field, Relationship, SQLModel
 
 if TYPE_CHECKING:
-    from .monster import MonsterDetail, MonsterDetailRead
+    from .monster import MonsterDetail
 
 
 class MonsterFamilyBase(SQLModel):
@@ -21,11 +21,3 @@ class MonsterFamily(MonsterFamilyBase, table=True):
 
     id: Optional[int] = Field(default=None, primary_key=True)
     monsters: List["MonsterDetail"] = Relationship(back_populates="family")
-
-
-class MonsterFamilyRead(MonsterFamilyBase):
-    id: int
-
-
-class MonsterFamilyReadWithMonsterDetail(MonsterFamilyRead):
-    monsters: List["MonsterDetailRead"] = []

--- a/src/app/models/dqm1/monster_family.py
+++ b/src/app/models/dqm1/monster_family.py
@@ -1,0 +1,31 @@
+from typing import List, Optional, TYPE_CHECKING
+
+from sqlmodel import Field, Relationship, SQLModel
+
+if TYPE_CHECKING:
+    from .monster import MonsterDetail, MonsterDetailRead
+
+
+class MonsterFamilyBase(SQLModel):
+    """
+    There are 10 monster families in the game.
+    """
+
+    family_eng: str
+
+
+class MonsterFamily(MonsterFamilyBase, table=True):
+    """
+    one-to-many relation between family and monsters.
+    """
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    monsters: List["MonsterDetail"] = Relationship(back_populates="family")
+
+
+class MonsterFamilyRead(MonsterFamilyBase):
+    id: int
+
+
+class MonsterFamilyReadWithMonsterDetail(MonsterFamilyRead):
+    monsters: List["MonsterDetailRead"] = []

--- a/src/app/models/dqm1/schemas.py
+++ b/src/app/models/dqm1/schemas.py
@@ -1,0 +1,55 @@
+from typing import List, Optional
+
+from .monster import MonsterBreedingLinkBase, MonsterDetailBase
+from .monster_family import MonsterFamilyBase
+from .skill import Skill, SkillBase, SkillCombineBase
+
+
+class MonsterFamilyRead(MonsterFamilyBase):
+    id: int
+
+
+class MonsterFamilyReadWithMonsterDetail(MonsterFamilyRead):
+    monsters: List["MonsterDetailRead"] = []
+
+
+class MonsterDetailRead(MonsterDetailBase):
+    id: int
+
+
+class MonsterDetailWithFamily(MonsterDetailRead):
+    family: Optional[MonsterFamilyRead] = None
+
+
+class MonsterBreedingLinkRead(MonsterBreedingLinkBase):
+    id: int
+
+
+class MonsterBreedingLinkReadWithInfo(MonsterBreedingLinkRead):
+    child: Optional[MonsterDetailRead]
+    pedigree: Optional[MonsterDetailRead]
+    parent2: Optional[MonsterDetailRead]
+    pedigree_family: Optional[MonsterFamilyRead]
+    family2: Optional[MonsterFamilyRead]
+
+
+class SkillRead(SkillBase):
+    id: int
+
+
+class SkillReadWithMonster(SkillRead):
+    monsters: Optional[MonsterDetailRead]
+
+
+class SkillUpgradeRead(SkillRead):
+    upgrade_to: Optional[Skill]
+    upgrade_from: Optional[Skill]
+
+
+class MonsterDetailSkill(MonsterDetailWithFamily):
+    skills: List[SkillRead] = []
+
+
+class SkillCombineRead(SkillCombineBase):
+    id: int
+    needed_skill: Optional[SkillRead]

--- a/src/app/models/dqm1/skill.py
+++ b/src/app/models/dqm1/skill.py
@@ -1,20 +1,11 @@
 from typing import List, Optional, TYPE_CHECKING
 
 from sqlmodel import Field, Relationship, SQLModel
-from .monster import (
-    MonsterDetail,
-    MonsterSkillLink,
-    MonsterDetailRead,
-    MonsterDetailWithFamily,
-)
+
+from .associations import MonsterSkillLink
 
 if TYPE_CHECKING:
-    from .monster import (
-        MonsterDetail,
-        MonsterSkillLink,
-        MonsterDetailRead,
-        MonsterDetailWithFamily,
-    )
+    from .monster import MonsterDetail
 
 
 class SkillBase(SQLModel):
@@ -70,23 +61,6 @@ class Skill(SkillBase, table=True):
     )
 
 
-class SkillRead(SkillBase):
-    id: int
-
-
-class SkillReadWithMonster(SkillRead):
-    monsters: Optional[MonsterDetailRead]
-
-
-class SkillUpgradeRead(SkillRead):
-    upgrade_to: Optional[Skill]
-    upgrade_from: Optional[Skill]
-
-
-class MonsterDetailSkill(MonsterDetailWithFamily):
-    skills: List[SkillRead] = []
-
-
 class SkillCombineBase(SQLModel):
     combo_skill_id: Optional[int] = Field(default=None, foreign_key="skill.id")
     needed_skill_id: Optional[int] = Field(default=None, foreign_key="skill.id")
@@ -113,8 +87,3 @@ class SkillCombine(SkillCombineBase, table=True):
             "lazy": "joined",
         }
     )
-
-
-class SkillCombineRead(SkillCombineBase):
-    id: int
-    needed_skill: Optional[SkillRead]

--- a/src/app/routers/dqm1_endpoints.py
+++ b/src/app/routers/dqm1_endpoints.py
@@ -16,6 +16,8 @@ from src.app.models.dqm1.monster import (
     MonsterBreedingLinkReadWithInfo,
     MonsterDetail,
     MonsterDetailWithFamily,
+)
+from src.app.models.dqm1.monster_family import (
     MonsterFamily,
     MonsterFamilyReadWithMonsterDetail,
 )

--- a/src/app/routers/dqm1_endpoints.py
+++ b/src/app/routers/dqm1_endpoints.py
@@ -11,23 +11,17 @@ from src.app.models.dqm1.enums import (
     SkillFamily,
 )
 from src.app.models.dqm1.item import Item
-from src.app.models.dqm1.monster import (
-    MonsterBreedingLink,
+from src.app.models.dqm1.monster import MonsterBreedingLink, MonsterDetail
+from src.app.models.dqm1.monster_family import MonsterFamily
+from src.app.models.dqm1.schemas import (
     MonsterBreedingLinkReadWithInfo,
-    MonsterDetail,
-    MonsterDetailWithFamily,
-)
-from src.app.models.dqm1.monster_family import (
-    MonsterFamily,
-    MonsterFamilyReadWithMonsterDetail,
-)
-from src.app.models.dqm1.skill import (
     MonsterDetailSkill,
-    Skill,
-    SkillCombine,
+    MonsterDetailWithFamily,
+    MonsterFamilyReadWithMonsterDetail,
     SkillCombineRead,
     SkillUpgradeRead,
 )
+from src.app.models.dqm1.skill import Skill, SkillCombine
 
 router = APIRouter(
     prefix="/dqm1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,9 +12,9 @@ from src.app.models.dqm1.item import Item
 from src.app.models.dqm1.monster import (
     MonsterBreedingLink,
     MonsterDetail,
-    MonsterFamily,
     MonsterSkillLink,
 )
+from src.app.models.dqm1.monster_family import MonsterFamily
 from src.app.models.dqm1.skill import Skill, SkillCombine
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,10 +9,10 @@ from sqlmodel.pool import StaticPool
 from src.app.database import get_session
 from src.app.main import app
 from src.app.models.dqm1.item import Item
+from src.app.models.dqm1.associations import MonsterSkillLink
 from src.app.models.dqm1.monster import (
     MonsterBreedingLink,
     MonsterDetail,
-    MonsterSkillLink,
 )
 from src.app.models.dqm1.monster_family import MonsterFamily
 from src.app.models.dqm1.skill import Skill, SkillCombine

--- a/tests/test_insert_data.py
+++ b/tests/test_insert_data.py
@@ -5,9 +5,9 @@ from src.app.models.dqm1.item import Item
 from src.app.models.dqm1.monster import (
     MonsterBreedingLink,
     MonsterDetail,
-    MonsterFamily,
     MonsterSkillLink,
 )
+from src.app.models.dqm1.monster_family import MonsterFamily
 from src.app.models.dqm1.skill import Skill, SkillCombine
 
 


### PR DESCRIPTION
Key changes include:
- Resolved Circular Import Issues: Addressed `PydanticUndefinedAnnotation` errors that prevented the application from loading due to circular dependencies between `monster` and `skill` models. This was primarily fixed by moving API-facing schema models (e.g., `MonsterDetailRead`, `SkillUpgradeRead`) into a new `src/app/models/dqm1/schemas.py` file. 
- Isolating the `MonsterSkillLink` association table into its own `src/app/models/dqm1/associations.py` file. This breaks the runtime dependency deadlock between `monster.py` and `skill.py`.
